### PR TITLE
Add customer id and Client id to user model

### DIFF
--- a/identity-service/pom.xml
+++ b/identity-service/pom.xml
@@ -70,6 +70,10 @@
             <groupId>org.hsqldb</groupId>
             <artifactId>hsqldb</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.datastax.cassandra</groupId>
+            <artifactId>cassandra-driver-core</artifactId>
+        </dependency>
     </dependencies>
     <build>
         <sourceDirectory>${project.basedir}/src/main/java</sourceDirectory>

--- a/identity-service/src/main/java/com/hashmapinc/haf/constants/ModelConstants.java
+++ b/identity-service/src/main/java/com/hashmapinc/haf/constants/ModelConstants.java
@@ -8,6 +8,8 @@ public class ModelConstants {
     public static final String ID_PROPERTY = "id";
     public static final String USER_NAME_PROPERTY = "user_name";
     public static final String TENANT_ID_PROPERTY = "tenant_id";
+    public static final String CUSTOMER_ID_PROPERTY = "customer_id";
+    public static final String CLIENT_ID_PROPERTY = "client_id";
     public static final String USER_FIRST_NAME_PROPERTY = "first_name";
     public static final String USER_LAST_NAME_PROPERTY = "last_name";
     public static final String USER_PASSWORD_PROPERTY = "password";

--- a/identity-service/src/main/java/com/hashmapinc/haf/controllers/UserController.java
+++ b/identity-service/src/main/java/com/hashmapinc/haf/controllers/UserController.java
@@ -19,6 +19,7 @@ import java.net.URI;
 import java.security.Principal;
 import java.util.Collection;
 import java.util.Optional;
+import java.util.UUID;
 
 @RestController
 @RequestMapping("/users")
@@ -40,8 +41,8 @@ public class UserController {
 
     @PreAuthorize("#oauth2.hasAnyScope('server', 'ui')")
     @RequestMapping(value = "/{userId}", method = RequestMethod.GET)
-    public ResponseEntity<?> getUserById(@PathVariable String userId){
-        String clientId = getCurrentClientId();
+    public ResponseEntity<?> getUserById(@PathVariable UUID userId){
+        //String clientId = getCurrentClientId();
         User user = userService.findById(userId);
         if(user == null)
             return new ResponseEntity<>("No User found with id "+ userId, HttpStatus.NO_CONTENT);
@@ -53,7 +54,7 @@ public class UserController {
     public ResponseEntity<?> save(@RequestBody User user){
         String clientId = getCurrentClientId();
         if(provider.equalsIgnoreCase("database")) {
-            if(userService.findById(user.getId()) == null) {
+            if(user.getId() == null || userService.findById(user.getId()) == null) {
                 User savedUser = userService.save(user);
                 URI uri = ServletUriComponentsBuilder
                         .fromCurrentRequest()

--- a/identity-service/src/main/java/com/hashmapinc/haf/controllers/UserController.java
+++ b/identity-service/src/main/java/com/hashmapinc/haf/controllers/UserController.java
@@ -8,12 +8,17 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.provider.OAuth2Authentication;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
 import java.net.URI;
 import java.security.Principal;
 import java.util.Collection;
+import java.util.Optional;
 
 @RestController
 @RequestMapping("/users")
@@ -25,13 +30,27 @@ public class UserController {
     @Value("${users.provider}")
     private String provider;
 
+    @Value("${spring.application.name}")
+    private String identityServiceName;
+
     @RequestMapping(value = "/current", method = RequestMethod.GET)
     public Principal getUser(Principal principal) {
         return principal;
     }
 
+    @PreAuthorize("#oauth2.hasAnyScope('server', 'ui')")
+    @RequestMapping(value = "/{userId}", method = RequestMethod.GET)
+    public ResponseEntity<?> getUserById(@PathVariable String userId){
+        User user = userService.findById(userId);
+        if(user == null)
+            return new ResponseEntity<>("No User found with id "+ userId, HttpStatus.NO_CONTENT);
+        return ResponseEntity.ok(user);
+    }
+
+    @PreAuthorize("#oauth2.hasAnyScope('server', 'ui')")
     @RequestMapping(method = RequestMethod.POST, consumes = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<?> save(@RequestBody User user){
+        String clientId = getCurrentClientId();
         if(provider.equalsIgnoreCase("database")) {
             if(userService.findById(user.getId()) == null) {
                 User savedUser = userService.save(user);
@@ -51,19 +70,21 @@ public class UserController {
                     .body("User can't be created as provider is set to " + provider);
     }
 
-    @RequestMapping(value = "/{userId}", method = RequestMethod.GET)
-    public ResponseEntity<?> getUserById(@PathVariable String userId){
-        User user = userService.findById(userId);
-        if(user == null)
-            return new ResponseEntity<>("No User found with id "+ userId, HttpStatus.NO_CONTENT);
-        return ResponseEntity.ok(user);
-    }
-
+    @PreAuthorize("#oauth2.hasAnyScope('server', 'ui')")
     @RequestMapping(method = RequestMethod.GET)
     public ResponseEntity<?> getAllUsers(){
         Collection<User> users = userService.findAll();
         if(users == null || users.isEmpty())
             return new ResponseEntity<>("No Users found", HttpStatus.NO_CONTENT);
         return ResponseEntity.ok(users);
+    }
+
+    private String getCurrentClientId(){
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if(authentication != null && authentication instanceof OAuth2Authentication){
+            OAuth2Authentication oauth = (OAuth2Authentication) authentication;
+            return oauth.getOAuth2Request().getClientId();
+        }
+        return identityServiceName;
     }
 }

--- a/identity-service/src/main/java/com/hashmapinc/haf/controllers/UserController.java
+++ b/identity-service/src/main/java/com/hashmapinc/haf/controllers/UserController.java
@@ -1,7 +1,6 @@
 package com.hashmapinc.haf.controllers;
 
 import com.hashmapinc.haf.models.User;
-import com.hashmapinc.haf.models.UserInformation;
 import com.hashmapinc.haf.services.UserDetailsService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
@@ -18,7 +17,6 @@ import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 import java.net.URI;
 import java.security.Principal;
 import java.util.Collection;
-import java.util.Optional;
 import java.util.UUID;
 
 @RestController
@@ -55,6 +53,9 @@ public class UserController {
         String clientId = getCurrentClientId();
         if(provider.equalsIgnoreCase("database")) {
             if(user.getId() == null || userService.findById(user.getId()) == null) {
+                if(user.getClientId() == null){
+                    user.setClientId(clientId);
+                }
                 User savedUser = userService.save(user);
                 URI uri = ServletUriComponentsBuilder
                         .fromCurrentRequest()
@@ -75,7 +76,7 @@ public class UserController {
     @PreAuthorize("#oauth2.hasAnyScope('server', 'ui')")
     @RequestMapping(method = RequestMethod.GET)
     public ResponseEntity<?> getAllUsers(){
-        Collection<User> users = userService.findAll();
+        Collection<User> users = userService.findAllByClientId(getCurrentClientId());
         if(users == null || users.isEmpty())
             return new ResponseEntity<>("No Users found", HttpStatus.NO_CONTENT);
         return ResponseEntity.ok(users);

--- a/identity-service/src/main/java/com/hashmapinc/haf/controllers/UserController.java
+++ b/identity-service/src/main/java/com/hashmapinc/haf/controllers/UserController.java
@@ -41,6 +41,7 @@ public class UserController {
     @PreAuthorize("#oauth2.hasAnyScope('server', 'ui')")
     @RequestMapping(value = "/{userId}", method = RequestMethod.GET)
     public ResponseEntity<?> getUserById(@PathVariable String userId){
+        String clientId = getCurrentClientId();
         User user = userService.findById(userId);
         if(user == null)
             return new ResponseEntity<>("No User found with id "+ userId, HttpStatus.NO_CONTENT);

--- a/identity-service/src/main/java/com/hashmapinc/haf/dao/UsersDao.java
+++ b/identity-service/src/main/java/com/hashmapinc/haf/dao/UsersDao.java
@@ -16,5 +16,5 @@ public interface UsersDao {
 
     User findById(UUID userId);
 
-    Collection<User> findAll();
+    Collection<User> findAllByClientId(String clientId);
 }

--- a/identity-service/src/main/java/com/hashmapinc/haf/dao/UsersDao.java
+++ b/identity-service/src/main/java/com/hashmapinc/haf/dao/UsersDao.java
@@ -4,6 +4,7 @@ package com.hashmapinc.haf.dao;
 import com.hashmapinc.haf.models.User;
 
 import java.util.Collection;
+import java.util.UUID;
 
 public interface UsersDao {
 
@@ -13,7 +14,7 @@ public interface UsersDao {
 
     void deleteById(String userId);
 
-    User findById(String userId);
+    User findById(UUID userId);
 
     Collection<User> findAll();
 }

--- a/identity-service/src/main/java/com/hashmapinc/haf/dao/UsersDao.java
+++ b/identity-service/src/main/java/com/hashmapinc/haf/dao/UsersDao.java
@@ -7,7 +7,7 @@ import java.util.Collection;
 
 public interface UsersDao {
 
-    User findByUserName(String userName);
+    User findByUserName(String userName, String clientId);
 
     User save(User user);
 

--- a/identity-service/src/main/java/com/hashmapinc/haf/dao/UsersDaoImpl.java
+++ b/identity-service/src/main/java/com/hashmapinc/haf/dao/UsersDaoImpl.java
@@ -21,8 +21,8 @@ public class UsersDaoImpl implements UsersDao{
     BCryptPasswordEncoder encoder;
 
     @Override
-    public User findByUserName(String userName) {
-        List<UserEntity> userEntities = usersRepository.findByUserName(userName);
+    public User findByUserName(String userName, String clientId) {
+        List<UserEntity> userEntities = usersRepository.findByUserNameAndClientId(userName, clientId);
         if(userEntities != null && !userEntities.isEmpty()){
             UserEntity user = userEntities.get(0);
             if(user != null){

--- a/identity-service/src/main/java/com/hashmapinc/haf/dao/UsersDaoImpl.java
+++ b/identity-service/src/main/java/com/hashmapinc/haf/dao/UsersDaoImpl.java
@@ -1,16 +1,18 @@
 package com.hashmapinc.haf.dao;
 
+import com.datastax.driver.core.utils.UUIDs;
 import com.hashmapinc.haf.entity.UserEntity;
 import com.hashmapinc.haf.models.User;
 import com.hashmapinc.haf.repository.UsersRepository;
+import com.hashmapinc.haf.utils.UUIDConverter;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Component;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
+import java.util.UUID;
 
 @Component
 public class UsersDaoImpl implements UsersDao{
@@ -36,6 +38,9 @@ public class UsersDaoImpl implements UsersDao{
     public User save(User user) {
         String encoded = encoder.encode(user.getPassword());
         user.setPassword(encoded);
+        if(user.getId() == null){
+            user.setId(UUIDs.timeBased());
+        }
         return usersRepository.save(new UserEntity(user)).toData();
     }
 
@@ -45,8 +50,8 @@ public class UsersDaoImpl implements UsersDao{
     }
 
     @Override
-    public User findById(String userId) {
-        UserEntity user = usersRepository.findOne(userId);
+    public User findById(UUID userId) {
+        UserEntity user = usersRepository.findOne(UUIDConverter.fromTimeUUID(userId));
         if(user != null)
             return user.toData();
         return null;

--- a/identity-service/src/main/java/com/hashmapinc/haf/dao/UsersDaoImpl.java
+++ b/identity-service/src/main/java/com/hashmapinc/haf/dao/UsersDaoImpl.java
@@ -58,8 +58,8 @@ public class UsersDaoImpl implements UsersDao{
     }
 
     @Override
-    public Collection<User> findAll() {
-        return convertDataList(usersRepository.findAll());
+    public Collection<User> findAllByClientId(String clientId) {
+        return convertDataList(usersRepository.findByClientId(clientId));
     }
 
     private List<User> convertDataList(Iterable<UserEntity> toDataList){

--- a/identity-service/src/main/java/com/hashmapinc/haf/entity/UserEntity.java
+++ b/identity-service/src/main/java/com/hashmapinc/haf/entity/UserEntity.java
@@ -28,6 +28,12 @@ public class UserEntity implements Serializable{
     @Column(name = ModelConstants.TENANT_ID_PROPERTY)
     private String tenantId;
 
+    @Column(name = ModelConstants.CUSTOMER_ID_PROPERTY)
+    private String customerId;
+
+    @Column(name = ModelConstants.CLIENT_ID_PROPERTY)
+    private String clientId;
+
     @Column(name = ModelConstants.USER_ENABLED_PROPERTY)
     private boolean enabled;
 
@@ -57,6 +63,12 @@ public class UserEntity implements Serializable{
         if (user.getTenantId() != null) {
             this.tenantId = user.getTenantId();
         }
+        if (user.getClientId() != null) {
+            this.clientId = user.getClientId();
+        }
+        if (user.getCustomerId() != null) {
+            this.customerId = user.getCustomerId();
+        }
         this.firstName = user.getFirstName();
         this.lastName = user.getLastName();
     }
@@ -81,7 +93,8 @@ public class UserEntity implements Serializable{
         user.setEnabled(enabled);
         user.setFirstName(firstName);
         user.setLastName(lastName);
-
+        user.setClientId(clientId);
+        user.setCustomerId(customerId);
         return user;
     }
 
@@ -97,6 +110,9 @@ public class UserEntity implements Serializable{
         if (userName != null ? !userName.equals(that.userName) : that.userName != null) return false;
         if (password != null ? !password.equals(that.password) : that.password != null) return false;
         if (tenantId != null ? !tenantId.equals(that.tenantId) : that.tenantId != null) return false;
+        if (tenantId != null ? !tenantId.equals(that.tenantId) : that.tenantId != null) return false;
+        if (clientId != null ? !clientId.equals(that.clientId) : that.clientId != null) return false;
+        if (customerId != null ? !customerId.equals(that.customerId) : that.customerId != null) return false;
         if (firstName != null ? !firstName.equals(that.firstName) : that.firstName != null) return false;
         if (lastName != null ? !lastName.equals(that.lastName) : that.lastName != null) return false;
         return authorities != null ? authorities.equals(that.authorities) : that.authorities == null;
@@ -108,6 +124,8 @@ public class UserEntity implements Serializable{
         result = 31 * result + (userName != null ? userName.hashCode() : 0);
         result = 31 * result + (password != null ? password.hashCode() : 0);
         result = 31 * result + (tenantId != null ? tenantId.hashCode() : 0);
+        result = 31 * result + (clientId != null ? clientId.hashCode() : 0);
+        result = 31 * result + (customerId != null ? customerId.hashCode() : 0);
         result = 31 * result + (enabled ? 1 : 0);
         result = 31 * result + (firstName != null ? firstName.hashCode() : 0);
         result = 31 * result + (lastName != null ? lastName.hashCode() : 0);

--- a/identity-service/src/main/java/com/hashmapinc/haf/entity/UserEntity.java
+++ b/identity-service/src/main/java/com/hashmapinc/haf/entity/UserEntity.java
@@ -3,6 +3,7 @@ package com.hashmapinc.haf.entity;
 
 import com.hashmapinc.haf.constants.ModelConstants;
 import com.hashmapinc.haf.models.User;
+import com.hashmapinc.haf.utils.UUIDConverter;
 
 import javax.persistence.*;
 import java.io.Serializable;
@@ -54,7 +55,7 @@ public class UserEntity implements Serializable{
 
     public UserEntity(User user) {
         if (user.getId() != null) {
-            this.setId(user.getId());
+            this.setId(UUIDConverter.fromTimeUUID(user.getId()));
         }
         this.userName = user.getUserName();
         this.enabled = user.isEnabled();
@@ -81,8 +82,12 @@ public class UserEntity implements Serializable{
         return this.id;
     }
 
+    public String getClientId() {
+        return clientId;
+    }
+
     public User toData() {
-        User user = new User(getId());
+        User user = new User(UUIDConverter.fromString(getId()));
         //user.setCreatedTime(UUIDs.unixTimestamp(getId()));
         user.setAuthorities(authorities);
         if (tenantId != null) {

--- a/identity-service/src/main/java/com/hashmapinc/haf/install/IdentityInstallationService.java
+++ b/identity-service/src/main/java/com/hashmapinc/haf/install/IdentityInstallationService.java
@@ -1,5 +1,6 @@
 package com.hashmapinc.haf.install;
 
+import com.datastax.driver.core.utils.UUIDs;
 import com.hashmapinc.haf.models.User;
 import com.hashmapinc.haf.services.UserDetailsService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -9,6 +10,7 @@ import org.springframework.stereotype.Service;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.Arrays;
+import java.util.UUID;
 
 @Service
 public class IdentityInstallationService {
@@ -32,7 +34,8 @@ public class IdentityInstallationService {
 
         schemaService.createDatabaseSchema();
 
-        User user = new User("123456");
+        User user = new User(UUIDs.timeBased());
+        user.setClientId("identity-service");
         user.setUserName("demo");
         user.setPassword("demo");
         user.setTenantId("hashmapInc");

--- a/identity-service/src/main/java/com/hashmapinc/haf/models/User.java
+++ b/identity-service/src/main/java/com/hashmapinc/haf/models/User.java
@@ -10,6 +10,8 @@ public class User implements UserInformation, Serializable{
     private String id;
     private String userName;
     private String tenantId;
+    private String customerId;
+    private String clientId;
     private String firstName;
     private String lastName;
     private List<String> authorities;
@@ -29,6 +31,8 @@ public class User implements UserInformation, Serializable{
         this.userName = user.getUserName();
         this.password = user.getPassword();
         this.tenantId = user.getTenantId();
+        this.customerId = user.getCustomerId();
+        this.clientId = user.getClientId();
         this.authorities = user.getAuthorities();
         this.firstName = user.getFirstName();
         this.lastName = user.getLastName();
@@ -102,6 +106,22 @@ public class User implements UserInformation, Serializable{
 
     public void setEnabled(boolean enabled) {
         this.enabled = enabled;
+    }
+
+    public String getCustomerId() {
+        return customerId;
+    }
+
+    public void setCustomerId(String customerId) {
+        this.customerId = customerId;
+    }
+
+    public String getClientId() {
+        return clientId;
+    }
+
+    public void setClientId(String clientId) {
+        this.clientId = clientId;
     }
 
     @Override

--- a/identity-service/src/main/java/com/hashmapinc/haf/models/User.java
+++ b/identity-service/src/main/java/com/hashmapinc/haf/models/User.java
@@ -1,13 +1,15 @@
 package com.hashmapinc.haf.models;
 
+import com.datastax.driver.core.utils.UUIDs;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.io.Serializable;
 import java.util.List;
+import java.util.UUID;
 
 public class User implements UserInformation, Serializable{
     private static final long serialVersionUID = -350874482962054954L;
 
-    private String id;
+    private UUID id;
     private String userName;
     private String tenantId;
     private String customerId;
@@ -20,9 +22,11 @@ public class User implements UserInformation, Serializable{
     private String password;
     private boolean enabled;
 
-    public User(){}
+    public User(){
+        this(UUIDs.timeBased());
+    }
 
-    public User(String id){
+    public User(UUID id){
         this.id = id;
     }
 
@@ -43,11 +47,11 @@ public class User implements UserInformation, Serializable{
         return serialVersionUID;
     }
 
-    public String getId() {
+    public UUID getId() {
         return id;
     }
 
-    public void setId(String id) {
+    public void setId(UUID id) {
         this.id = id;
     }
 

--- a/identity-service/src/main/java/com/hashmapinc/haf/models/UserInformation.java
+++ b/identity-service/src/main/java/com/hashmapinc/haf/models/UserInformation.java
@@ -19,4 +19,8 @@ public interface UserInformation {
     String getLastName();
 
     String getTenantId();
+
+    String getCustomerId();
+
+    String getClientId();
 }

--- a/identity-service/src/main/java/com/hashmapinc/haf/models/UserInformation.java
+++ b/identity-service/src/main/java/com/hashmapinc/haf/models/UserInformation.java
@@ -1,6 +1,7 @@
 package com.hashmapinc.haf.models;
 
 import java.util.List;
+import java.util.UUID;
 
 public interface UserInformation {
 
@@ -12,7 +13,7 @@ public interface UserInformation {
 
     String getUserName();
 
-    String getId();
+    UUID getId();
 
     String getFirstName();
 

--- a/identity-service/src/main/java/com/hashmapinc/haf/providers/KerberosIdentityProvider.java
+++ b/identity-service/src/main/java/com/hashmapinc/haf/providers/KerberosIdentityProvider.java
@@ -35,7 +35,7 @@ public class KerberosIdentityProvider extends CustomAuthenticationProvider{
         String validatedUsername = kerberosClient.login(auth.getName(), auth.getCredentials().toString());
         UserInformation userDetails = this.userDetailsService.loadUserByUsername(validatedUsername, "clientId");
         //SecurityUser securityUser = mapper.map(userDetails, userPrincipal);
-        return new UsernamePasswordAuthenticationToken(null, null, null);
+        return new UsernamePasswordAuthenticationToken(userDetails, null, null);
     }
 
 }

--- a/identity-service/src/main/java/com/hashmapinc/haf/providers/KerberosIdentityProvider.java
+++ b/identity-service/src/main/java/com/hashmapinc/haf/providers/KerberosIdentityProvider.java
@@ -33,7 +33,7 @@ public class KerberosIdentityProvider extends CustomAuthenticationProvider{
         Object principal = authentication.getPrincipal();
         UsernamePasswordAuthenticationToken auth = (UsernamePasswordAuthenticationToken) authentication;
         String validatedUsername = kerberosClient.login(auth.getName(), auth.getCredentials().toString());
-        UserInformation userDetails = this.userDetailsService.loadUserByUsername(validatedUsername);
+        UserInformation userDetails = this.userDetailsService.loadUserByUsername(validatedUsername, "clientId");
         //SecurityUser securityUser = mapper.map(userDetails, userPrincipal);
         return new UsernamePasswordAuthenticationToken(null, null, null);
     }

--- a/identity-service/src/main/java/com/hashmapinc/haf/repository/UsersRepository.java
+++ b/identity-service/src/main/java/com/hashmapinc/haf/repository/UsersRepository.java
@@ -9,5 +9,5 @@ import java.util.List;
 @Repository
 public interface UsersRepository extends JpaRepository<UserEntity, String> {
 
-    List<UserEntity> findByUserName(String userName);
+    List<UserEntity> findByUserNameAndClientId(String userName, String clientId);
 }

--- a/identity-service/src/main/java/com/hashmapinc/haf/repository/UsersRepository.java
+++ b/identity-service/src/main/java/com/hashmapinc/haf/repository/UsersRepository.java
@@ -10,4 +10,6 @@ import java.util.List;
 public interface UsersRepository extends JpaRepository<UserEntity, String> {
 
     List<UserEntity> findByUserNameAndClientId(String userName, String clientId);
+
+    List<UserEntity> findByClientId(String clientId);
 }

--- a/identity-service/src/main/java/com/hashmapinc/haf/services/DatabaseUserDetailsService.java
+++ b/identity-service/src/main/java/com/hashmapinc/haf/services/DatabaseUserDetailsService.java
@@ -10,6 +10,7 @@ import org.springframework.stereotype.Component;
 
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.UUID;
 
 @Component
 //@ConditionalOnProperty(value = "users.provider", havingValue = "database")
@@ -28,7 +29,7 @@ public class DatabaseUserDetailsService implements UserDetailsService {
     }
 
     @Override
-    public User findById(String id) {
+    public User findById(UUID id) {
         return usersDao.findById(id);
     }
 

--- a/identity-service/src/main/java/com/hashmapinc/haf/services/DatabaseUserDetailsService.java
+++ b/identity-service/src/main/java/com/hashmapinc/haf/services/DatabaseUserDetailsService.java
@@ -4,11 +4,9 @@ import com.hashmapinc.haf.dao.UsersDao;
 import com.hashmapinc.haf.models.User;
 import com.hashmapinc.haf.models.UserInformation;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Component;
 
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.UUID;
 
@@ -34,8 +32,8 @@ public class DatabaseUserDetailsService implements UserDetailsService {
     }
 
     @Override
-    public Collection<User> findAll() {
-        return usersDao.findAll();
+    public Collection<User> findAllByClientId(String clientId) {
+        return usersDao.findAllByClientId(clientId);
     }
 
     @Override

--- a/identity-service/src/main/java/com/hashmapinc/haf/services/DatabaseUserDetailsService.java
+++ b/identity-service/src/main/java/com/hashmapinc/haf/services/DatabaseUserDetailsService.java
@@ -18,8 +18,8 @@ public class DatabaseUserDetailsService implements UserDetailsService {
     @Autowired private UsersDao usersDao;
 
     @Override
-    public UserInformation loadUserByUsername(String s) throws UsernameNotFoundException {
-        return usersDao.findByUserName(s);
+    public UserInformation loadUserByUsername(String s, String clientId) throws UsernameNotFoundException {
+        return usersDao.findByUserName(s, clientId);
     }
 
     @Override

--- a/identity-service/src/main/java/com/hashmapinc/haf/services/UserDetailsService.java
+++ b/identity-service/src/main/java/com/hashmapinc/haf/services/UserDetailsService.java
@@ -15,7 +15,7 @@ public interface UserDetailsService {
 
     User findById(UUID id);
 
-    Collection<User> findAll();
+    Collection<User> findAllByClientId(String clientId);
 
     void deleteById(String userId);
 

--- a/identity-service/src/main/java/com/hashmapinc/haf/services/UserDetailsService.java
+++ b/identity-service/src/main/java/com/hashmapinc/haf/services/UserDetailsService.java
@@ -8,7 +8,7 @@ import java.util.Collection;
 
 public interface UserDetailsService {
 
-    UserInformation loadUserByUsername(String s) throws UsernameNotFoundException;
+    UserInformation loadUserByUsername(String s, String clientId) throws UsernameNotFoundException;
 
     User save(User user);
 

--- a/identity-service/src/main/java/com/hashmapinc/haf/services/UserDetailsService.java
+++ b/identity-service/src/main/java/com/hashmapinc/haf/services/UserDetailsService.java
@@ -5,6 +5,7 @@ import com.hashmapinc.haf.models.UserInformation;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 
 import java.util.Collection;
+import java.util.UUID;
 
 public interface UserDetailsService {
 
@@ -12,7 +13,7 @@ public interface UserDetailsService {
 
     User save(User user);
 
-    User findById(String id);
+    User findById(UUID id);
 
     Collection<User> findAll();
 

--- a/identity-service/src/main/java/com/hashmapinc/haf/tokens/DatabaseUserDetailsTokenConverter.java
+++ b/identity-service/src/main/java/com/hashmapinc/haf/tokens/DatabaseUserDetailsTokenConverter.java
@@ -32,6 +32,8 @@ public class DatabaseUserDetailsTokenConverter implements UserAuthenticationConv
         response.put("firstName", user.getUser().getFirstName());
         response.put("lastName", user.getUser().getLastName());
         response.put("tenant_id", user.getUser().getTenantId());
+        response.put("customer_id", user.getUser().getCustomerId());
+        response.put("client_id", user.getUser().getClientId());
         response.put("enabled", user.isEnabled());
         if(authentication.getAuthorities() != null && !authentication.getAuthorities().isEmpty()) {
             response.put("authorities", AuthorityUtils.authorityListToSet(authentication.getAuthorities()));
@@ -45,7 +47,7 @@ public class DatabaseUserDetailsTokenConverter implements UserAuthenticationConv
         if(map.containsKey("user_name")) {
             Object principal = map.get("user_name");
             //TODO: Make sure to get the User using tenant_id as well
-            UserInformation user = userDetailsService.loadUserByUsername((String) principal);
+            UserInformation user = userDetailsService.loadUserByUsername((String) principal, (String) map.get("client_id"));
 
             if(user != null) {
                 SecurityUser securityUser = new SecurityUser(user, user.isEnabled());

--- a/identity-service/src/main/java/com/hashmapinc/haf/utils/UUIDConverter.java
+++ b/identity-service/src/main/java/com/hashmapinc/haf/utils/UUIDConverter.java
@@ -1,0 +1,29 @@
+package com.hashmapinc.haf.utils;
+
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+public class UUIDConverter {
+
+    public static UUID fromString(String src) {
+        return UUID.fromString(src.substring(7, 15) + "-" + src.substring(3, 7) + "-1"
+                + src.substring(0, 3) + "-" + src.substring(15, 19) + "-" + src.substring(19));
+    }
+
+    public static String fromTimeUUID(UUID src) {
+        if (src.version() != 1) {
+            throw new IllegalArgumentException("Only Time-Based UUID (Version 1) is supported!");
+        }
+        String str = src.toString();
+        // 58e0a7d7-eebc-11d8-9669-0800200c9a66 => 1d8eebc58e0a7d796690800200c9a66. Note that [11d8] -> [1d8]
+        return str.substring(15, 18) + str.substring(9, 13) + str.substring(0, 8) + str.substring(19, 23) + str.substring(24);
+    }
+
+    public static List<String> fromTimeUUIDs(List<UUID> uuids) {
+        if (uuids == null) {
+            return null;
+        }
+        return uuids.stream().map(UUIDConverter::fromTimeUUID).collect(Collectors.toList());
+    }
+}

--- a/identity-service/src/main/resources/sql/identity-schema.sql
+++ b/identity-service/src/main/resources/sql/identity-schema.sql
@@ -5,6 +5,8 @@ create table if not exists haf_users (
     last_name varchar(255),
     password varchar(255),
     tenant_id varchar(255),
+    client_id varchar(255),
+    customer_id varchar(255),
     user_name varchar(255)
 );
 

--- a/identity-service/src/test/java/com/hashmapinc/haf/controllers/UserControllerTest.java
+++ b/identity-service/src/test/java/com/hashmapinc/haf/controllers/UserControllerTest.java
@@ -69,6 +69,7 @@ public class UserControllerTest {
         admin.setPassword("demo");
         admin.setEnabled(true);
         admin.setAuthorities(Arrays.asList("admin", "user"));
+        admin.setClientId(clientId);
         createUser(admin);
         admin.setPassword("demo");
 
@@ -76,6 +77,7 @@ public class UserControllerTest {
         user.setUserName("redTailUser");
         user.setPassword("password");
         user.setEnabled(true);
+        user.setClientId(clientId);
         user.setAuthorities(Arrays.asList("user"));
 
         createUser(user);

--- a/pom.xml
+++ b/pom.xml
@@ -33,6 +33,7 @@
         <akka.version>2.4.20</akka.version>
         <livy.version>0.3.0</livy.version>
         <docker.repository>hashmapinc</docker.repository>
+        <cassandra.version>3.3.0</cassandra.version>
     </properties>
 
     <modules>
@@ -384,6 +385,21 @@
                 <groupId>org.codehaus.janino</groupId>
                 <artifactId>commons-compiler</artifactId>
                 <version>2.7.8</version>
+            </dependency>
+            <dependency>
+                <groupId>com.datastax.cassandra</groupId>
+                <artifactId>cassandra-driver-core</artifactId>
+                <version>${cassandra.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.datastax.cassandra</groupId>
+                <artifactId>cassandra-driver-mapping</artifactId>
+                <version>${cassandra.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.datastax.cassandra</groupId>
+                <artifactId>cassandra-driver-extras</artifactId>
+                <version>${cassandra.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
Covered in PR:
1. Customer id and Client id added to user model and database.
2. While authentication client id will be used along with username to authenticate user, assumption is, for any project there will be only one client which will have password grant, that will be UI, and others will have client grant.
3. By associating client with user model we make sure to not add constraint of username to be unique across different services, but only for a given service, say HAF or Tempus.
4. Modified old id, which was String, to use Time based UUID.
5. Using String to represent tenant id and customer id as we are not user which will be format used by other services for ID i.e. it could be long, int or UUID
6. Updated Test cases

TODO:
1. Need to few more endpoints to retrieve user information by Tenant id and Customer id if needed.
2. There is another story for adding activation token support.
