### PR TITLE
Added support for persisting user permissions in identity service.

### DIFF
--- a/identity-service/src/main/java/com/hashmapinc/haf/constants/ModelConstants.java
+++ b/identity-service/src/main/java/com/hashmapinc/haf/constants/ModelConstants.java
@@ -14,8 +14,10 @@ public class ModelConstants {
     public static final String USER_LAST_NAME_PROPERTY = "last_name";
     public static final String USER_PASSWORD_PROPERTY = "password";
     public static final String USER_AUTHORITIES_COLUMN = "authorities_id";
+    public static final String USER_PERMISSIONS_COLUMN = "permission";
 
 
     public static final String USER_ENABLED_PROPERTY = "enabled";
     public static final String USER_AUTHORITIES_TABLE = "haf_user_authorities";
+    public static final String USER_PERMISSIONS_TABLE = "haf_user_permissions";
 }

--- a/identity-service/src/main/java/com/hashmapinc/haf/entity/UserEntity.java
+++ b/identity-service/src/main/java/com/hashmapinc/haf/entity/UserEntity.java
@@ -4,6 +4,8 @@ package com.hashmapinc.haf.entity;
 import com.hashmapinc.haf.constants.ModelConstants;
 import com.hashmapinc.haf.models.User;
 import com.hashmapinc.haf.utils.UUIDConverter;
+import org.hibernate.annotations.LazyCollection;
+import org.hibernate.annotations.LazyCollectionOption;
 
 import javax.persistence.*;
 import java.io.Serializable;
@@ -44,11 +46,17 @@ public class UserEntity implements Serializable{
     @Column(name = ModelConstants.USER_LAST_NAME_PROPERTY)
     private String lastName;
 
-    @ElementCollection(fetch = FetchType.EAGER)
+    @ElementCollection()
+    @LazyCollection(LazyCollectionOption.FALSE)
     @CollectionTable(name = ModelConstants.USER_AUTHORITIES_TABLE, joinColumns = @JoinColumn(name = ModelConstants.ID_PROPERTY))
     @Column(name = ModelConstants.USER_AUTHORITIES_COLUMN)
     private List<String> authorities;
 
+    @ElementCollection()
+    @LazyCollection(LazyCollectionOption.FALSE)
+    @CollectionTable(name = ModelConstants.USER_PERMISSIONS_TABLE, joinColumns = @JoinColumn(name = ModelConstants.ID_PROPERTY))
+    @Column(name = ModelConstants.USER_PERMISSIONS_COLUMN)
+    private List<String> permissions;
 
     public UserEntity() {
     }
@@ -61,6 +69,7 @@ public class UserEntity implements Serializable{
         this.enabled = user.isEnabled();
         this.password = user.getPassword();
         this.authorities = user.getAuthorities();
+        this.permissions = user.getPermissions();
         if (user.getTenantId() != null) {
             this.tenantId = user.getTenantId();
         }
@@ -90,6 +99,7 @@ public class UserEntity implements Serializable{
         User user = new User(UUIDConverter.fromString(getId()));
         //user.setCreatedTime(UUIDs.unixTimestamp(getId()));
         user.setAuthorities(authorities);
+        user.setPermissions(permissions);
         if (tenantId != null) {
             user.setTenantId(tenantId);
         }
@@ -115,11 +125,11 @@ public class UserEntity implements Serializable{
         if (userName != null ? !userName.equals(that.userName) : that.userName != null) return false;
         if (password != null ? !password.equals(that.password) : that.password != null) return false;
         if (tenantId != null ? !tenantId.equals(that.tenantId) : that.tenantId != null) return false;
-        if (tenantId != null ? !tenantId.equals(that.tenantId) : that.tenantId != null) return false;
         if (clientId != null ? !clientId.equals(that.clientId) : that.clientId != null) return false;
         if (customerId != null ? !customerId.equals(that.customerId) : that.customerId != null) return false;
         if (firstName != null ? !firstName.equals(that.firstName) : that.firstName != null) return false;
         if (lastName != null ? !lastName.equals(that.lastName) : that.lastName != null) return false;
+        if (permissions != null ? !permissions.equals(that.permissions) : that.permissions != null ) return false;
         return authorities != null ? authorities.equals(that.authorities) : that.authorities == null;
     }
 
@@ -135,6 +145,7 @@ public class UserEntity implements Serializable{
         result = 31 * result + (firstName != null ? firstName.hashCode() : 0);
         result = 31 * result + (lastName != null ? lastName.hashCode() : 0);
         result = 31 * result + (authorities != null ? authorities.hashCode() : 0);
+        result = 31 * result + (permissions != null ? permissions.hashCode() : 0);
         return result;
     }
 }

--- a/identity-service/src/main/java/com/hashmapinc/haf/models/User.java
+++ b/identity-service/src/main/java/com/hashmapinc/haf/models/User.java
@@ -17,6 +17,7 @@ public class User implements UserInformation, Serializable{
     private String firstName;
     private String lastName;
     private List<String> authorities;
+    private List<String> permissions;
 
     @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
     private String password;
@@ -38,6 +39,7 @@ public class User implements UserInformation, Serializable{
         this.customerId = user.getCustomerId();
         this.clientId = user.getClientId();
         this.authorities = user.getAuthorities();
+        this.permissions = user.getPermissions();
         this.firstName = user.getFirstName();
         this.lastName = user.getLastName();
         this.enabled = user.isEnabled();
@@ -91,6 +93,10 @@ public class User implements UserInformation, Serializable{
         return authorities;
     }
 
+    public List<String> getPermissions() {
+        return permissions;
+    }
+
     @Override
     public boolean isEnabled() {
         return this.enabled;
@@ -99,6 +105,8 @@ public class User implements UserInformation, Serializable{
     public void setAuthorities(List<String> authorities) {
         this.authorities = authorities;
     }
+
+    public void setPermissions(List<String> permissions) { this.permissions = permissions; }
 
     public String getPassword() {
         return password;
@@ -144,6 +152,8 @@ public class User implements UserInformation, Serializable{
             return false;
         if (getLastName() != null ? !getLastName().equals(user.getLastName()) : user.getLastName() != null)
             return false;
+        if (getPermissions() != null ? !getPermissions().equals(user.getPermissions()) : user.getPermissions() != null)
+            return false;
         return getAuthorities() != null ? getAuthorities().equals(user.getAuthorities()) : user.getAuthorities() == null;
     }
 
@@ -155,6 +165,7 @@ public class User implements UserInformation, Serializable{
         result = 31 * result + (getFirstName() != null ? getFirstName().hashCode() : 0);
         result = 31 * result + (getLastName() != null ? getLastName().hashCode() : 0);
         result = 31 * result + (getAuthorities() != null ? getAuthorities().hashCode() : 0);
+        result = 31 * result + (getPermissions() != null ? getPermissions().hashCode() : 0);
         return result;
     }
 }

--- a/identity-service/src/main/java/com/hashmapinc/haf/models/UserInformation.java
+++ b/identity-service/src/main/java/com/hashmapinc/haf/models/UserInformation.java
@@ -7,6 +7,8 @@ public interface UserInformation {
 
     List<String> getAuthorities();
 
+    List<String> getPermissions();
+
     boolean isEnabled();
 
     String getPassword();

--- a/identity-service/src/main/resources/sql/identity-schema.sql
+++ b/identity-service/src/main/resources/sql/identity-schema.sql
@@ -14,3 +14,8 @@ create table if not exists haf_user_authorities (
     user_id varchar(255),
     authorities_id varchar(255)
 );
+
+create table if not exists haf_user_permissions (
+    user_id varchar(255),
+    permission varchar(255)
+);

--- a/identity-service/src/test/java/com/hashmapinc/haf/controllers/UserControllerTest.java
+++ b/identity-service/src/test/java/com/hashmapinc/haf/controllers/UserControllerTest.java
@@ -9,7 +9,6 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.internal.matchers.EndsWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
@@ -24,13 +23,15 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.context.WebApplicationContext;
+
 import java.util.Arrays;
 import java.util.Map;
 import java.util.UUID;
 
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.httpBasic;
 import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @RunWith(SpringRunner.class)
@@ -72,6 +73,7 @@ public class UserControllerTest {
         admin.setPassword("demo");
         admin.setEnabled(true);
         admin.setAuthorities(Arrays.asList("admin", "user"));
+        admin.setPermissions(Arrays.asList("subject1:*"));
         admin.setClientId(clientId);
         createUser(admin);
         admin.setPassword("demo");
@@ -83,6 +85,7 @@ public class UserControllerTest {
         user.setEnabled(true);
         user.setClientId(clientId);
         user.setAuthorities(Arrays.asList("user"));
+        user.setPermissions(Arrays.asList("subject1:resource1:READ", "subject1:resource2:READ"));
 
         createUser(user);
         user.setPassword("password");
@@ -174,7 +177,8 @@ public class UserControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.id").value(user.getId().toString()))
                 .andExpect(jsonPath("$.userName").value(user.getUserName()))
-                .andExpect(jsonPath("$.password").doesNotExist());
+                .andExpect(jsonPath("$.password").doesNotExist())
+                .andExpect(jsonPath("$.permissions[0]").value(user.getPermissions().get(0)));
     }
 
     @Test


### PR DESCRIPTION
Added new table(haf_user_permissions) to have permission as string against user-ids.
DAO + Service + Controller changes done for saving and fetching permissions in User Model.