### PR TITLE
Haf 665 Delete User

### DIFF
--- a/identity-service/src/main/java/com/hashmapinc/haf/controllers/UserController.java
+++ b/identity-service/src/main/java/com/hashmapinc/haf/controllers/UserController.java
@@ -11,6 +11,7 @@ import com.hashmapinc.haf.requests.ActivateUserRequest;
 import com.hashmapinc.haf.requests.CreateUserRequest;
 import com.hashmapinc.haf.requests.CreateUserResponse;
 import com.hashmapinc.haf.services.UserDetailsService;
+import com.hashmapinc.haf.utils.UUIDConverter;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
@@ -236,7 +237,7 @@ public class UserController {
         UserCredentials credentials = userService.findCredentialsByUserId(userId);
         if(credentials != null)
             userService.deleteUserCredentialsById(credentials.getId());
-        userService.deleteById(userId.toString());
+        userService.deleteById(UUIDConverter.fromTimeUUID(userId));
         return ResponseEntity.ok("User with id "+ userId + " deleted successfully");
     }
 

--- a/identity-service/src/main/java/com/hashmapinc/haf/dao/UserCredentialsDaoImpl.java
+++ b/identity-service/src/main/java/com/hashmapinc/haf/dao/UserCredentialsDaoImpl.java
@@ -35,7 +35,10 @@ public class UserCredentialsDaoImpl implements UserCredentialsDao{
 
     @Override
     public UserCredentials findByUserId(UUID userId) {
-        return userCredentialsRepository.findByUserId(UUIDConverter.fromTimeUUID(userId)).toData();
+        UserCredentialsEntity userCredentialsEntity = userCredentialsRepository.findByUserId(UUIDConverter.fromTimeUUID(userId));
+        if (userCredentialsEntity != null)
+            return userCredentialsEntity.toData();
+        return null;
     }
 
     @Override
@@ -50,7 +53,7 @@ public class UserCredentialsDaoImpl implements UserCredentialsDao{
 
     @Override
     public void delete(UUID id) {
-        userCredentialsRepository.delete(id.toString());
+        userCredentialsRepository.delete(UUIDConverter.fromTimeUUID(id));
     }
 
 

--- a/identity-service/src/test/java/com/hashmapinc/haf/controllers/UserControllerTest.java
+++ b/identity-service/src/test/java/com/hashmapinc/haf/controllers/UserControllerTest.java
@@ -1,13 +1,10 @@
 package com.hashmapinc.haf.controllers;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.hashmapinc.haf.entity.UserCredentialsEntity;
 import com.hashmapinc.haf.models.ActivationType;
 import com.hashmapinc.haf.models.User;
 import com.hashmapinc.haf.models.UserCredentials;
-import com.hashmapinc.haf.repository.UserCredentialsRepository;
 import com.hashmapinc.haf.requests.CreateUserRequest;
 import com.hashmapinc.haf.services.DatabaseUserDetailsService;
 import org.junit.Assert;
@@ -23,7 +20,6 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.context.web.WebAppConfiguration;
 import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.util.LinkedMultiValueMap;
@@ -37,6 +33,7 @@ import java.util.UUID;
 
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.httpBasic;
 import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
@@ -90,6 +87,14 @@ public class UserControllerTest {
         createUser(user);
 
         adminToken = obtainAccessToken("demo", "password");
+    }
+
+    @Test
+    public void deleteUser() throws Exception {
+        mockMvc.perform(
+                delete("/users/" + user.getId())
+                        .header("Authorization" , "Bearer " + adminToken)
+        ).andExpect(status().isOk());
     }
 
     @Test


### PR DESCRIPTION
Card : [#665 ](https://waffle.io/hashmapinc/Tempus/cards/5b7e65546a0572001b5a0362)
From Tempus UI User in Business Unit were not getting deleted.

Changed the way to convert UUID to string using UUIDConverter.
Added unit test for delete user controller.